### PR TITLE
Use DelayedQueue to expose Tokens

### DIFF
--- a/src/main/java/chat/amy/bucket/TokenAPI.java
+++ b/src/main/java/chat/amy/bucket/TokenAPI.java
@@ -6,7 +6,7 @@ import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.concurrent.TimeUnit;
+import java.time.temporal.ChronoUnit;
 
 /**
  * @author amy
@@ -17,11 +17,7 @@ import java.util.concurrent.TimeUnit;
 public class TokenAPI {
     private final Logger logger = LoggerFactory.getLogger("TokenAPI");
     
-    private final TokenService tokenService = new TokenService(0, 5, TimeUnit.SECONDS);
-    
-    public TokenAPI() {
-        tokenService.startAsync();
-    }
+    private final TokenService tokenService = new TokenService(0, 5, ChronoUnit.SECONDS);
     
     @RequestMapping("/token")
     public boolean getToken() {

--- a/src/main/java/chat/amy/bucket/TokenService.java
+++ b/src/main/java/chat/amy/bucket/TokenService.java
@@ -1,50 +1,87 @@
 package chat.amy.bucket;
 
-import com.google.common.util.concurrent.AbstractScheduledService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.Collections;
+import java.util.Queue;
 import java.util.UUID;
+import java.util.concurrent.DelayQueue;
+import java.util.concurrent.Delayed;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * @author amy
  * @since 9/8/17.
  */
-public class TokenService extends AbstractScheduledService {
-    private final int initialDelay;
+public class TokenService {
+
     private final int delay;
-    private final TimeUnit unit;
-    private final AtomicBoolean tokenAvailable = new AtomicBoolean(true);
-    
+    private final ChronoUnit unit;
+    private final Queue<Token> tokens;
+
     private final Logger logger = LoggerFactory.getLogger("TokenService " + UUID.randomUUID());
-    
-    public TokenService(final int initialDelay, final int delay, final TimeUnit unit) {
-        this.initialDelay = initialDelay;
+
+    public TokenService(final int initialDelay, final int delay, final ChronoUnit unit) {
         this.delay = delay;
         this.unit = unit;
+
+        this.tokens = new DelayQueue<>(Collections.singleton(
+                new Token(initialDelay, unit)
+        ));
     }
-    
+
     public boolean getToken() {
-        if(tokenAvailable.get()) {
-            tokenAvailable.set(false);
-            return true;
-        } else {
-            return false;
-        }
-    }
-    
-    @Override
-    protected void runOneIteration() throws Exception {
-        if(!tokenAvailable.get()) {
+        Token poll = tokens.poll();
+        if (poll != null) {
             logger.info("Provisioning new token (" + delay + " interval).");
-            tokenAvailable.set(true);
+            tokens.add(new Token(delay, unit));
+        } else {
+            logger.info("Nope, wait {} more ms", tokens.peek().getDelay(TimeUnit.MILLISECONDS));
         }
+        return poll != null;
     }
-    
-    @Override
-    protected Scheduler scheduler() {
-        return Scheduler.newFixedDelaySchedule(initialDelay, delay, unit);
+
+    /**
+     * A delayed Token, that doesn't exist before the {@link #delay}.
+     */
+    private static class Token implements Delayed {
+
+        /**
+         * The moment the Token can be polled.
+         */
+        private final LocalDateTime delay;
+
+        Token(long delay, ChronoUnit unit) {
+            this.delay = LocalDateTime.now().plus(delay, unit);
+        }
+
+        @Override
+        public long getDelay(TimeUnit unit) {
+            long nanosToGo = ChronoUnit.NANOS.between(LocalDateTime.now(), delay);
+            return unit.convert(nanosToGo, TimeUnit.NANOSECONDS);
+        }
+
+        /**
+         * An unimplemented compareTo, because we don't need it.
+         *
+         * In the DelayedQueue there is never more than one element.
+         * This means we can just skip this.
+         *
+         * Also it's way too hard to implement.
+         * <ol>
+         * <li>Downcast to Token and compare delays?</li>
+         * <li>getDelay on both and hope for the same nanosecond tick?</li>
+         * </ol>
+         *
+         * @param o
+         * @return
+         */
+        @Override
+        public int compareTo(Delayed o) {
+            throw new UnsupportedOperationException("Impossible to implement, possibly relies on outside factors.");
+        }
     }
 }


### PR DESCRIPTION
This does away with the guava service, and ensures no tokens can be
handed out within 5 seconds of each other.

P.S the `Nope, wait {} more ms` can be removed, but I wanted to show that you can accurately predict when the token can be polled.